### PR TITLE
Fix clone URI

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,7 +10,7 @@ export async function getSmackage(compiler: string): Promise<void> {
   // Step 2. (Ignored.)
 
   // Step 3. Download.
-  await exec.exec("git", ["clone", "git://github.com/standardml/smackage.git"]);
+  await exec.exec("git", ["clone", "git@github.com:standardml/smackage.git"]);
   await exec.exec("make", [compiler], { cwd: "smackage" });
 
   // Step 4. Update your PATH.


### PR DESCRIPTION
Fixes:
```
Cloning into 'smackage'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```